### PR TITLE
🚀 Fix Newsletter Slug Conflicts & Improve Post-Send Navigation

### DIFF
--- a/src/app/api/newsletter/send/route.ts
+++ b/src/app/api/newsletter/send/route.ts
@@ -82,7 +82,13 @@ export async function POST(request: Request) {
     await mailchimp.campaigns.setContent(campaign.id, { html: finalHtml });
     await mailchimp.campaigns.send(campaign.id);
 
-    return NextResponse.json({ message: 'Campaign sent successfully!', campaignId: campaign.id });
+    // Return campaign ID, post ID, and slug for proper redirection
+    return NextResponse.json({
+      message: 'Campaign sent successfully!',
+      campaignId: campaign.id,
+      postId: savedPost.id,
+      slug: savedPost.slug // Include the slug for redirection to public post page
+    });
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   } catch (error: any) {

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -233,11 +233,11 @@ export default function HomePage() {
             variants={heroItemVariants}
           >
             <Image
-              src="https://pvbdrbaquwivhylsmagn.supabase.co/storage/v1/object/public/tst-assets/website%20assets/cho-cloud-hero.png"
+              src="https://pvbdrbaquwivhylsmagn.supabase.co/storage/v1/object/public/tst-assets/website%20assets/Hero%20Bean%20Bun.png"
               alt="Therapy illustration"
-              width={500}
-              height={500}
-              className="w-full h-auto max-w-md mx-auto"
+              width={600}
+              height={600}
+              className="w-full h-auto max-w-xl mx-auto"
               priority
             />
           </motion.div>

--- a/src/lib/email-template.ts
+++ b/src/lib/email-template.ts
@@ -106,8 +106,8 @@ export const getEmailHtml = (data: any): string => {
                 <tr>
                   <td style="background-color:#ffffff; border:3px solid #000000; ">
                     <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0">
-                      <tr><td><img src="${data.main_image_url}" width="640" alt="Main Article" style="width:100%; max-width:100%; height:auto; border-radius:9px 9px 0 0;"></td></tr>
-                      <tr><td style="padding:20px 30px 0 30px;" class="mobile-padding"><h2 class="h2" style="font-family:'Work Sans',Arial,sans-serif; font-size:28px; font-weight:bold; color:#000000; margin:0;">${data.main_title}</h2></td></tr>
+                      <tr><td><img src="${data.main_image_url}" width="640" alt="Main Article" style="width:100%; max-width:100%; height:auto;"></td></tr>
+                      <tr><td style="padding:20px 30px 0 30px;" class="mobile-padding"><h2 class="h2" style="font-family:'Work Sans',Arial,sans-serif; font-size:30px; font-weight:bold; color:#000000; margin:0;">${data.main_title}</h2></td></tr>
                       <tr><td style="padding:15px 30px 30px 30px;" class="mobile-padding">${data.main_body}</td></tr>
                     </table>
                   </td>


### PR DESCRIPTION
### Problem
- **Duplicate Slug Issue**: Newsletters with identical titles created conflicting slugs, causing database errors and broken post pages
- **Poor UX**: After sending newsletters, users were redirected to the newsletter list instead of seeing the published result

### Solution
#### 🔧 Enhanced Slug Generation
- Added `generateUniqueSlug()` function that checks for existing slugs and appends timestamps when conflicts occur
- Maintains clean URLs for first occurrence while ensuring uniqueness for duplicates
- Includes proper error handling with fallback slug generation

#### 🎯 Improved Navigation Flow
- **Save Draft**: Redirects to newsletter editor for continued editing
- **Send Newsletter**: Redirects to public post page (`/posts/{slug}`) so users can see the published result
- Updated API to return both `postId` and `slug` for flexible redirection options

### Changes Made
#### Frontend (`NewsletterEditor.tsx`)
- Added unique slug generation with database conflict checking
- Updated save/send handlers with proper error handling
- Modified redirect logic based on action type

#### Backend (`/api/newsletter/send`)
- Updated API response to include `slug` field
- Ensured proper data return for redirection

### Testing
- Create newsletters with identical titles ✅
- Verify unique slugs are generated ✅
- Test save vs send redirect behavior ✅
- Confirm post pages load correctly ✅

### Impact
- ✅ Eliminates slug conflicts and database errors
- ✅ Improves user experience with logical post-action navigation
- ✅ Maintains SEO-friendly URLs while ensuring uniqueness
- ✅ Provides immediate feedback by showing published newsletter