### PR TITLE
Replace Manual GA4 Tracking with Google Tag Manager Integration

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -6,6 +6,7 @@ import Footer from "@/components/Footer/Footer";
 import { Toaster } from "react-hot-toast";
 import { Analytics } from "@vercel/analytics/next"
 import CookieConsent from "@/components/CookieConsent/CookieConsent";
+import Script from 'next/script';
 
 const workSans = Work_Sans({
   subsets: ["latin"],
@@ -59,21 +60,19 @@ export default function RootLayout({
           dangerouslySetInnerHTML={{ __html: JSON.stringify(medicalBusinessSchema) }}
         />
 
-  {/* ✅ Google Analytics Tag */}
-  <script async src={`https://www.googletagmanager.com/gtag/js?id=${process.env.NEXT_PUBLIC_GA_MEASUREMENT_ID}`} />
-
-  <script
-    dangerouslySetInnerHTML={{
-      __html: `
-        window.dataLayer = window.dataLayer || [];
-        function gtag(){dataLayer.push(arguments);}
-        gtag('js', new Date());
-        gtag('config', '${process.env.NEXT_PUBLIC_GA_MEASUREMENT_ID}', {
-          debug_mode: true
-        });
-      `,
-    }}
-  />
+<Script
+  id="gtm-init"
+  strategy="afterInteractive"
+  dangerouslySetInnerHTML={{
+    __html: `
+      (function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+      new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+      j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+      'https://www.googletagmanager.com/gtm.js?id=GTM-N6VXX6CK'+dl;f.parentNode.insertBefore(j,f);
+      })(window,document,'script','dataLayer','GTM-N6VXX6CK');
+    `,
+  }}
+/>
       </head>
       <body
         className={`${workSans.variable} font-sans bg-tst-cream text-black antialiased`}
@@ -84,8 +83,16 @@ export default function RootLayout({
            <Analytics />
         </main>
         <Footer />
-         
+
         <CookieConsent />
+<noscript>
+  <iframe
+    src="https://www.googletagmanager.com/ns.html?id=GTM-N6VXX6CK"
+    height="0"
+    width="0"
+    style={{ display: 'none', visibility: 'hidden' }}
+  />
+</noscript>
       </body>
     </html>
   );


### PR DESCRIPTION
Replace Manual GA4 Tracking with Google Tag Manager Integration

### ✅ Summary
This PR removes manual GA4 tracking logic from the contact form submission handler and integrates Google Tag Manager (GTM) for centralized analytics tracking across the site.

---

### 🔧 Changes
- Removed custom tracking functions:
  - `trackContactFormConversion`
  - `trackFormSubmission`
- Deleted GA4 event tracking calls from `handleSubmit` in the contact form
- Added GTM script to `<head>` and `<body>` in the `RootLayout`:
  - Container ID: `GTM-N6VXX6CK`

---

### 🎯 Why
- Centralize all tracking in GTM for easier management
- Reduce client-side JS bundle size
- Avoid redundancy with multiple analytics tags
- Enable no-code event and tag configuration through GTM

---

### 📌 Notes
- All GA4 and Google Ads tracking will now be routed through GTM
- Be sure to configure a GTM trigger for the contact form to emit `tst_contact_lead` with `source` (homepage/contact) as a parameter
- Confirm the tag is firing properly in GTM’s Preview/Debug mode before publishing