### PR TITLE
Improve Contact page SEO for “queer asian therapist atlanta” and streamline conversions.

### DIFF
--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -1,35 +1,95 @@
 // src/app/about/page.tsx
 import type { Metadata } from 'next';
+import Script from 'next/script';
 import AboutPageClient from '@/components/clients/AboutPageClient/AboutPageClient';
 
+const canonical = 'https://toastedsesametherapy.com/about';
+
 export const metadata: Metadata = {
-  title: 'About Kay | Toasted Sesame Therapy',
-  description: 'Meet Kay (she/they), a Korean American, queer, and neurodivergent therapist dedicated to providing identity-centered care.'
+  title: 'Queer Asian Therapist in Atlanta | About Kay',
+  description:
+    'Kay (she/they) is a queer Korean American therapist in Atlanta providing trauma‑informed, identity‑centered therapy. Virtual sessions across Georgia.',
+  alternates: { canonical },
+  openGraph: {
+    url: canonical,
+    title: 'Queer Asian Therapist in Atlanta | About Kay',
+    description:
+      'Identity‑centered, trauma‑informed therapy for queer, Asian, and neurodivergent clients. Based in Atlanta. Georgia telehealth available.',
+    type: 'profile'
+  },
+  twitter: {
+    card: 'summary_large_image',
+    title: 'Queer Asian Therapist in Atlanta | About Kay',
+    description:
+      'Trauma‑informed, identity‑centered therapy for queer, Asian, and neurodivergent clients in Atlanta and across Georgia.'
+  }
 };
 
 export default function AboutPage() {
-  const personSchema = {
-    "@context": "https://schema.org",
-    "@type": "Person",
-    "name": "Kay",
-    "jobTitle": "Licensed Professional Counselor",
-    "image": "https://pvbdrbaquwivhylsmagn.supabase.co/storage/v1/object/public/tst-assets/website%20assets/MYT-v2.png",
-    "url": "https://toastedsesametherapy.com/about",
-    "sameAs": [
-      // Add links to social media profiles if available
-    ],
-    "worksFor": {
-      "@type": "Organization",
-      "name": "Toasted Sesame Therapy"
-    }
+  const jsonLd = {
+    '@context': 'https://schema.org',
+    '@graph': [
+      {
+        '@type': 'Person',
+        name: 'Kay',
+        jobTitle: 'Licensed Professional Counselor',
+        image:
+          'https://pvbdrbaquwivhylsmagn.supabase.co/storage/v1/object/public/tst-assets/website%20assets/MYT-v2.png',
+        url: canonical,
+        worksFor: { '@type': 'Organization', name: 'Toasted Sesame Therapy', url: 'https://toastedsesametherapy.com/' },
+        knowsAbout: [
+          'Complex trauma',
+          'C-PTSD',
+          'Neurodivergence',
+          'LGBTQ+ affirming therapy',
+          'Asian American mental health'
+        ],
+        areaServed: {
+          '@type': 'City',
+          name: 'Atlanta',
+          address: { '@type': 'PostalAddress', addressRegion: 'GA', addressCountry: 'US' }
+        }
+      },
+      {
+        '@type': 'Service',
+        name: 'Trauma-Informed Psychotherapy',
+        provider: { '@type': 'Organization', name: 'Toasted Sesame Therapy' },
+        serviceType: 'Psychotherapy',
+        areaServed: 'Georgia',
+        availableChannel: {
+          '@type': 'ServiceChannel',
+          serviceUrl: 'https://toastedsesametherapy.com/therapy-services',
+          availableLanguage: ['English']
+        }
+      },
+      {
+        '@type': 'FAQPage',
+        mainEntity: [
+          {
+            '@type': 'Question',
+            name: 'Do you work with queer Asian clients in Atlanta?',
+            acceptedAnswer: {
+              '@type': 'Answer',
+              text:
+                'Yes. I specialize in identity-centered care for queer and Asian clients in Atlanta with virtual sessions available across Georgia.'
+            }
+          },
+          {
+            '@type': 'Question',
+            name: 'Do you offer virtual therapy across Georgia?',
+            acceptedAnswer: {
+              '@type': 'Answer',
+              text: 'Yes. All sessions are held virtually for clients located anywhere in Georgia.'
+            }
+          }
+        ]
+      }
+    ]
   };
 
   return (
     <>
-      <script
-        type="application/ld+json"
-        dangerouslySetInnerHTML={{ __html: JSON.stringify(personSchema) }}
-      />
+      <Script id="about-jsonld" type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }} />
       <AboutPageClient />
     </>
   );

--- a/src/app/contact/page.tsx
+++ b/src/app/contact/page.tsx
@@ -1,38 +1,91 @@
 // src/app/contact/page.tsx
 import type { Metadata } from 'next';
+import Script from 'next/script';
 import ContactPageClient from '@/components/clients/ContactPageClient/ContactPageClient';
-import { faqData } from '@/data/faqData'; // Import the FAQ data
+import { faqData } from '@/data/faqData';
+
+const canonical = 'https://toastedsesametherapy.com/contact';
 
 export const metadata: Metadata = {
-  title: 'Contact & Book a Consultation | Toasted Sesame Therapy',
-  description: 'Ready to start? Reach out to book a free, no-pressure 15-minute consultation. Your journey toward healing is one conversation away.'
+  title: 'Contact a Queer Asian Therapist in Atlanta | Book a Consultation',
+  description:
+    'Ready to start? Contact Kay, a queer Korean American therapist in Atlanta. Book a no-pressure 15-minute consultation. Virtual therapy across Georgia.',
+  alternates: { canonical },
+  openGraph: {
+    url: canonical,
+    title: 'Contact a Queer Asian Therapist in Atlanta | Book a Consultation',
+    description:
+      'Reach out to Kay for a free 15-minute consult. Identity-centered, trauma-informed therapy in Atlanta and across Georgia via telehealth.'
+  },
+  twitter: {
+    card: 'summary_large_image',
+    title: 'Contact a Queer Asian Therapist in Atlanta | Book a Consultation',
+    description:
+      'Book a 15-minute consult with Kay. Identity-centered, trauma-informed therapy for queer, Asian, and neurodivergent clients in Georgia.'
+  }
 };
 
 export default function ContactPage() {
-  // Generate the JSON for the schema
   const faqSchema = {
-    "@context": "https://schema.org",
-    "@type": "FAQPage",
-    "mainEntity": faqData.map(item => ({
-      "@type": "Question",
-      "name": item.question,
-      "acceptedAnswer": {
-        "@type": "Answer",
-        // This removes any HTML like <br /> for the schema script
-        "text": item.answer.replace(/<[^>]*>?/gm, ' ')
+    '@type': 'FAQPage',
+    mainEntity: faqData.map(item => ({
+      '@type': 'Question',
+      name: item.question,
+      acceptedAnswer: {
+        '@type': 'Answer',
+        text: item.answer.replace(/<[^>]*>?/gm, ' ')
       }
     }))
   };
 
+  const jsonLd = {
+    '@context': 'https://schema.org',
+    '@graph': [
+      {
+        '@type': 'BreadcrumbList',
+        itemListElement: [
+          { '@type': 'ListItem', position: 1, name: 'Home', item: 'https://toastedsesametherapy.com/' },
+          { '@type': 'ListItem', position: 2, name: 'Contact', item: canonical }
+        ]
+      },
+      {
+        '@type': 'ContactPage',
+        name: 'Contact — Book a Consultation',
+        url: canonical,
+        about: {
+          '@type': 'Person',
+          name: 'Kay'
+        }
+      },
+      {
+        '@type': 'Organization',
+        name: 'Toasted Sesame Therapy',
+        url: 'https://toastedsesametherapy.com/',
+        contactPoint: [{
+          '@type': 'ContactPoint',
+          contactType: 'customer support',
+          areaServed: 'US-GA',
+          availableLanguage: ['English']
+        }]
+      },
+      {
+        '@type': 'Service',
+        name: 'Trauma-Informed Psychotherapy',
+        serviceType: 'Psychotherapy',
+        provider: { '@type': 'Organization', name: 'Toasted Sesame Therapy' },
+        areaServed: 'Georgia',
+        availableChannel: {
+          '@type': 'ServiceChannel',
+          serviceUrl: 'https://toastedsesametherapy.com/therapy-services'
+        }
+      },
+      faqSchema
+    ]
+  };
+
   return (
     <>
-      {/* Add the schema script here */}
-      <script
-        type="application/ld+json"
-        dangerouslySetInnerHTML={{ __html: JSON.stringify(faqSchema) }}
-      />
-
-      {/* Render the client component */}
+      <Script id="contact-jsonld" type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }} />
       <ContactPageClient />
     </>
   );

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,420 +1,79 @@
-"use client";
+// src/app/page.tsx (SERVER COMPONENT)
+import type { Metadata } from 'next';
+import Script from 'next/script';
+import HomePageClient from '@/components/clients/HomePageClient/HomePageClient';
 
-import { motion, useInView } from "framer-motion";
-import { useRef } from "react";
-import { useRouter } from 'next/navigation';
-import dynamic from 'next/dynamic';
-import Section from "@/components/Section/Section";
-import TestimonialCard from "@/components/TestimonialCard/TestimonialCard";
-import Image from "next/image";
-import Button from "@/components/Button/Button";
-import CircleIcon from "@/components/CircleIcon/CircleIcon";
-import AnimatedCheckbox from "@/components/AnimatedCheckbox/AnimatedCheckbox";
-import ProfileImage from "@/components/ProfileImage/ProfileImage";
-import HoverLink from '@/components/HoverLink/HoverLink';
-import { LottiePlayer } from "@/components/LottiePlayer/LottiePlayer";
-import {tiredAnimation} from "@/data/animations";
-import {
-  socialProofIcons,
-  testimonials,
-  checklistItems,
-  meetYourTherapist,
-  howItWorksSteps,
-  trustIndicators,
-} from "@/data/pageData";
-import ContactForm from "@/components/Contact/ContactForm";
+const canonical = 'https://toastedsesametherapy.com/';
 
-const TherapyCard = dynamic(() => import("@/components/TherapyCard/TherapyCard"), {
-  loading: () => (
-    <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-8">
-      {[...Array(4)].map((_, i) => (
-        <div key={i} className="animate-pulse bg-gray-200 rounded-lg h-64 border-2 border-black"></div>
-      ))}
-    </div>
-  ),
-});
-
-const HowItWorksStep = dynamic(() => import("@/components/HowItWorksSteps/HowItWorksSteps"), {
-  loading: () => (
-    <div className="animate-pulse bg-gray-200 rounded-lg h-48 border-2 border-black"></div>
-  ),
-});
-
-const LeadMagnet = dynamic(() => import("@/components/LeadMagnet/LeadMagnet"), {
-  loading: () => (
-    <div className="animate-pulse bg-gray-200 rounded-lg h-96 border-2 border-black"></div>
-  ),
-});
-
-
-// Animation variants
-const heroContainerVariants = {
-  hidden: { opacity: 0 },
-  visible: {
-    opacity: 1,
-    transition: { staggerChildren: 0.07 },
+export const metadata: Metadata = {
+  metadataBase: new URL('https://toastedsesametherapy.com'),
+  title: 'Therapy That Fits You, As You Are | Toasted Sesame Therapy',
+  description:
+    'Identity-centered, trauma-informed therapy for adults. Atlanta-based with virtual care across Georgia. Queer- and Asian-owned practice led by Kay (she/they).',
+  alternates: { canonical },
+  openGraph: {
+    url: canonical,
+    siteName: 'Toasted Sesame Therapy',
+    title: 'Therapy That Fits You, As You Are',
+    description:
+      'Identity-centered, trauma-informed therapy for adults in Atlanta and across Georgia via telehealth.',
+    type: 'website',
+  },
+  twitter: {
+    card: 'summary_large_image',
+    title: 'Therapy That Fits You, As You Are',
+    description:
+      'Trauma‑informed, identity‑centered therapy for adults in Atlanta & across Georgia.',
+  },
+  robots: {
+    index: true,
+    follow: true,
+    googleBot: { index: true, follow: true },
+  },
+  icons: {
+    icon: '/favicon.ico',
+    apple: '/apple-touch-icon.png',
   },
 };
 
-const heroItemVariants = {
-  hidden: { y: 50, opacity: 0 },
-  visible: {
-    y: 0,
-    opacity: 1,
-    transition: { duration: 0.4 },
-  },
-};
-
-const containerVariants = {
-  hidden: { opacity: 0 },
-  visible: {
-    opacity: 1,
-    transition: { staggerChildren: 0.1, delayChildren: 0.1 },
-  },
-};
-
-const itemVariants = {
-  hidden: { y: 20, opacity: 0 },
-  visible: {
-    y: 0,
-    opacity: 1,
-    transition: { duration: 0.5 },
-  },
-};
-
-const sectionVariants = {
-  hidden: { opacity: 0 },
-  visible: {
-    opacity: 1,
-    transition: { duration: 0.5 },
-  },
-};
-
-// Component for the tired animation section
-const TiredAnimationSection = ({width, height}) => {
-  return (
-    <div className="w-full h-full">
-      <LottiePlayer
-        file={tiredAnimation}
-        width={width}
-        height={height}
-        loop={true}
-        autoplay={true}
-        speed={1}
-        alt=""
-      />
-    </div>
-  );
-};
-
-export default function HomePage() {
-  const howItWorksRef = useRef(null);
-
-  // Create individual refs for each step
-  const step0Ref = useRef<HTMLDivElement>(null);
-  const step1Ref = useRef<HTMLDivElement>(null);
-  const step2Ref = useRef<HTMLDivElement>(null);
-  const step3Ref = useRef<HTMLDivElement>(null);
-
-  // Track which steps are in view using individual refs
-  const step0InView = useInView(step0Ref, { once: true, amount: 0.5 });
-  const step1InView = useInView(step1Ref, { once: true, amount: 0.5 });
-  const step2InView = useInView(step2Ref, { once: true, amount: 0.5 });
-  const step3InView = useInView(step3Ref, { once: true, amount: 0.5 });
-
-  // Create array of step visibility states
-  const stepInViewStates = [step0InView, step1InView, step2InView, step3InView];
-
-  // Create array of refs for easy access in the map
-  const stepRefs = [step0Ref, step1Ref, step2Ref, step3Ref];
-
-  const handleScroll = (e: React.MouseEvent<HTMLButtonElement>) => {
-    e.preventDefault();
-    const contactForm = document.getElementById("contact-form");
-    if (contactForm) {
-      contactForm.scrollIntoView({
-        behavior: "smooth",
-        block: "start",
-      });
-    }
-  };
-
-  const router = useRouter();
-
-  const handleResourcesClick = () => {
-    router.push('/guides');
+export default function Page() {
+  const jsonLd = {
+    '@context': 'https://schema.org',
+    '@graph': [
+      {
+        '@type': 'Organization',
+        name: 'Toasted Sesame Therapy',
+        url: canonical,
+        sameAs: [
+          // add socials if you want them recognized
+          'https://www.instagram.com/toastedsesametherapy'
+        ],
+      },
+      {
+        '@type': 'WebSite',
+        name: 'Toasted Sesame Therapy',
+        url: canonical,
+      },
+      {
+        '@type': 'WebPage',
+        '@id': canonical + '#home',
+        url: canonical,
+        name: 'Therapy That Fits You, As You Are',
+        isPartOf: { '@id': canonical },
+      },
+      {
+        '@type': 'BreadcrumbList',
+        itemListElement: [
+          { '@type': 'ListItem', position: 1, name: 'Home', item: canonical },
+        ],
+      },
+    ],
   };
 
   return (
-    <main>
-      <Section className="pb-32" minHeight="100vh">
-        <motion.div
-          className="grid grid-cols-1 md:grid-cols-2 gap-16 items-center min-h-500"
-          variants={heroContainerVariants}
-          initial="hidden"
-          animate="visible"
-        >
-          <motion.div
-            className="flex flex-col gap-4"
-            variants={heroContainerVariants}
-          >
-           <motion.div variants={heroItemVariants}>
-  <Image
-    src="https://pvbdrbaquwivhylsmagn.supabase.co/storage/v1/object/public/tst-assets/logo/tst-logo-long-baseline.svg"
-    alt="Tst Logo"
-    width={600}
-    height={600}
-  />
-</motion.div>
-            <motion.h1
-              className="text-5xl lg:text-6xl font-extrabold leading-tight"
-              variants={heroItemVariants}
-            >
-              For the deep feelers, drained hearts, and healing seekers.
-            </motion.h1>
-            <motion.p className="text-lg" variants={heroItemVariants}>
-              You&apos;ve carried too much for too long. It&apos;s time to finally care
-              for you.
-            </motion.p>
-
-            <motion.div
-              className="flex flex-col md:flex-row flex-wrap gap-4 pt-4"
-              variants={heroItemVariants}
-            >
-              <Button onClick={handleScroll} className="bg-tst-yellow" id="book-a-call-btn">
-                Book a call
-              </Button>
-              <Button onClick={handleResourcesClick} className="bg-white" id="download-free-guides-btn">
-               Download Your Free Guides
-              </Button>
-            </motion.div>
-<motion.div
-  className="flex flex-row gap-4 flex-wrap justify-center md:justify-start"
-  variants={heroItemVariants}
->
-  {trustIndicators.map((indicator) => (
-    <div key={indicator.id} className="flex items-center gap-3">
-      <CircleIcon
-        size="xs"
-        bgColor="bg-green-100"
-        iconUrl={indicator.iconUrl}
-      />
-      <span className="font-bold">{indicator.text}</span>
-    </div>
-  ))}
-</motion.div>
-            <motion.div
-              className="pt-6 flex flex-col items-center text-center md:flex-row md:items-start md:text-left gap-4"
-              variants={heroItemVariants}
-            >
-              <div className="flex flex-shrink-0">
-                {socialProofIcons.map((icon, index) => (
-                  <CircleIcon
-                    key={index}
-                    size="sm"
-                    bgColor={icon.bgColor}
-                    iconUrl={icon.iconUrl}
-                    altText={icon.altText}
-                    wrapperClassName={icon.className}
-                  />
-                ))}
-              </div>
-              <p className="text-sm font-medium">
-                <strong>More than 200+ people</strong> have taken the first
-                step.
-                <br />
-                You&apos;re not alone.
-              </p>
-            </motion.div>
-          </motion.div>
-
-          <motion.div
-            className="flex items-center justify-center"
-            variants={heroItemVariants}
-          >
-            <Image
-              src="https://pvbdrbaquwivhylsmagn.supabase.co/storage/v1/object/public/tst-assets/website%20assets/Hero%20Bean%20Bun.png"
-              alt="Therapy illustration"
-              width={600}
-              height={600}
-              className="w-full h-auto max-w-xl mx-auto"
-              priority
-            />
-          </motion.div>
-        </motion.div>
-
-        <motion.div
-          className="grid grid-cols-1 md:grid-cols-3 gap-y-12 md:gap-x-8 mt-16"
-          variants={containerVariants}
-          initial="hidden"
-          whileInView="visible"
-          viewport={{ once: true, amount: 0.2 }}
-        >
-          {testimonials.map((testimonial, index) => (
-            <motion.div key={index} variants={itemVariants}>
-              <TestimonialCard
-                quote={testimonial.quote}
-                iconUrl={testimonial.iconUrl}
-                bgColor={testimonial.bgColor}
-                altText={testimonial.altText}
-              />
-            </motion.div>
-          ))}
-        </motion.div>
-        <motion.p
-          className="text-center italic mt-16 max-w-2xl mx-auto"
-          variants={sectionVariants}
-          initial="hidden"
-          whileInView="visible"
-          viewport={{ once: true, amount: 0.2 }}
-        >
-          Each reflection is based on real things clients have shared,
-          thoughtfully paraphrased to honor both their meaning and their
-          privacy.
-        </motion.p>
-      </Section>
-
-      <div className="border-t-2 border-black">
-        <Section className="bg-tst-yellow" minHeight="750px">
-          <motion.div
-            className="bg-white border-2 border-black rounded-xl shadow-brutalistLg p-8 md:p-12"
-            variants={sectionVariants}
-            initial="hidden"
-            whileInView="visible"
-            viewport={{ once: true, amount: 0.2 }}
-          >
-            <div className="grid md:grid-cols-2 gap-8 items-center">
-              <div className="flex flex-col gap-6">
-                <h2 className="text-4xl md:text-5xl font-extrabold">
-                  Check all that sound like you.
-                </h2>
-
-                <div className="block md:hidden w-56 mx-auto aspect-square">
-                  <TiredAnimationSection width={200} height={200}/>
-                </div>
-
-              <div className="flex flex-col gap-4">
-                {checklistItems.map((item) => (
-                <AnimatedCheckbox key={item.id} id={item.id} label={item.label} />
-                ))}
-                </div>
-                <div className="pt-4">
-                  <Button onClick={handleScroll} className="bg-tst-purple" id="checkbox-get-started-btn">
-                    Get Started
-                  </Button>
-                </div>
-              </div>
-
-              <div className="hidden md:block max-w-sm mx-auto aspect-square">
-                <TiredAnimationSection width={400} height={400}/>
-              </div>
-            </div>
-
-          </motion.div>
-        </Section>
-      </div>
-
-      <div className="border-t-2 border-black">
-        <LeadMagnet />
-      </div>
-
-      <div className="border-t-2 border-black">
-        <Section className="bg-tst-purple" minHeight="1000px">
-          <motion.div
-            className="text-center mb-12"
-            variants={sectionVariants}
-            initial="hidden"
-            whileInView="visible"
-            viewport={{ once: true, amount: 0.2 }}
-          >
-            <h2 className="text-5xl font-extrabold">
-              Therapy that actually gets you
-            </h2>
-          </motion.div>
-          <TherapyCard />
-        </Section>
-      </div>
-
-      <div>
-        <Section minHeight="400px" className="border-t-2 border-black">
-          <motion.div
-            className="grid md:grid-cols-2 gap-12 md:gap-16 items-center min-h-400"
-            variants={sectionVariants}
-            initial="hidden"
-            whileInView="visible"
-            viewport={{ once: true, amount: 0.2 }}
-          >
-            <div className="flex justify-center">
-              <ProfileImage />
-            </div>
-
-            <motion.div
-              className="flex flex-col gap-4"
-              variants={containerVariants}
-            >
-              <motion.h2
-                className="text-5xl font-extrabold"
-                variants={itemVariants}
-              >
-                {meetYourTherapist.title}
-              </motion.h2>
-              {meetYourTherapist.paragraphs.map((text, index) => (
-                <motion.p
-                  key={index}
-                  className="text-lg"
-                  variants={itemVariants}
-                >
-                  {text}
-                </motion.p>
-              ))}
-              <motion.div variants={itemVariants} className="relative">
-  <div className="absolute left-0" style={{ marginLeft: '-22px' }}>
-    <HoverLink href="/about" className="group gap-2 font-bold text-lg text-tst-purple">
-      <span>Read my full bio</span>
-    </HoverLink>
-  </div>
-</motion.div>
-            </motion.div>
-          </motion.div>
-        </Section>
-      </div>
-
-      <div ref={howItWorksRef}>
-        <Section minHeight="1000px">
-          <motion.div
-            className="text-center mb-12"
-            initial={{ opacity: 0 }}
-            whileInView={{ opacity: 1 }}
-            viewport={{ once: true, amount: 0.5 }}
-            transition={{ duration: 0.5 }}
-          >
-            <h2 className="text-6xl font-extrabold">
-              What working together looks like
-            </h2>
-          </motion.div>
-          <div className="flex flex-col min-h-1000">
-            {howItWorksSteps.map((step, index) => {
-              const currentRef = stepRefs[index];
-              const nextStepInView = index < howItWorksSteps.length - 1 ? stepInViewStates[index + 1] : false;
-
-              return (
-                <div key={index} ref={currentRef}>
-                  <HowItWorksStep
-                    step={step}
-                    index={index}
-                    isLastStep={step.isLastStep}
-                    nextStepInView={nextStepInView}
-                  />
-                </div>
-              );
-            })}
-          </div>
-        </Section>
-      </div>
-
-      <Section>
-        <ContactForm id="contact-form"/>
-      </Section>
-    </main>
+    <>
+      <Script id="home-jsonld" type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }} />
+      <HomePageClient />
+    </>
   );
 }

--- a/src/app/therapy-services/page.tsx
+++ b/src/app/therapy-services/page.tsx
@@ -1,69 +1,98 @@
 // src/app/therapy-services/page.tsx
 import type { Metadata } from 'next';
+import Script from 'next/script';
 import ServicesPageClient from '@/components/clients/ServicesPageClient/ServicesPageClient';
 import { faqData } from '@/data/faqData';
 import { ourApproachData } from '@/data/servicesPageData';
 
+const canonical = 'https://toastedsesametherapy.com/therapy-services';
+
 export const metadata: Metadata = {
-  title: 'Therapy Services | Toasted Sesame Therapy',
-  description: 'Explore our neuro-affirming, trauma-informed, and somatic therapy services. Personalized online therapy that fits you, as you are.'
+  title: 'Trauma Therapy in Atlanta | Queer Asian Therapist | Toasted Sesame Therapy',
+  description:
+    'Identity-centered, trauma-informed therapy in Atlanta and across Georgia via telehealth. Support for complex trauma, C-PTSD, queer and Asian clients, and neurodivergent folks.',
+  alternates: { canonical },
+  openGraph: {
+    url: canonical,
+    title: 'Trauma Therapy in Atlanta | Toasted Sesame Therapy',
+    description:
+      'Trauma-informed, identity-centered therapy for adults in Atlanta and across Georgia.',
+  },
+  twitter: {
+    card: 'summary_large_image',
+    title: 'Trauma Therapy in Atlanta | Toasted Sesame Therapy',
+    description:
+      'Identity-centered, trauma-informed therapy for adults in Atlanta and across Georgia.',
+  },
 };
 
 export default function ServicesPage() {
-  // Generate the JSON for the schema
   const faqSchema = {
-    "@context": "https://schema.org",
-    "@type": "FAQPage",
-    "mainEntity": faqData.map(item => ({
-      "@type": "Question",
-      "name": item.question,
-      "acceptedAnswer": {
-        "@type": "Answer",
-        // This removes any HTML like <br /> for the schema script
-        "text": item.answer.replace(/<[^>]*>?/gm, ' ')
+    '@type': 'FAQPage',
+    mainEntity: faqData.map(item => ({
+      '@type': 'Question',
+      name: item.question,
+      acceptedAnswer: {
+        '@type': 'Answer',
+        text: item.answer.replace(/<[^>]*>?/gm, ' ')
       }
     }))
   };
 
-   const serviceSchema = {
-    "@context": "https://schema.org",
-    "@type": "Service",
-    "serviceType": "Individual Therapy",
-    "provider": {
-      "@type": "MedicalBusiness",
-      "name": "Toasted Sesame Therapy"
+  const serviceSchema = {
+    '@type': 'Service',
+    name: 'Trauma-Informed Psychotherapy',
+    serviceType: 'Psychotherapy',
+    description:
+      'One-on-one identity-centered, trauma-informed therapy for adults, including support for complex trauma and C-PTSD.',
+    areaServed: ['Atlanta, GA', 'Georgia'],
+    availableChannel: {
+      '@type': 'ServiceChannel',
+      serviceUrl: canonical,
+      availableLanguage: ['English']
     },
-    "description": "One-on-one support in a supportive space to help you feel less alone.",
-    "areaServed": {
-      "@type": "State",
-      "name": "Georgia"
+    provider: {
+      '@type': 'Organization',
+      name: 'Toasted Sesame Therapy',
+      url: 'https://toastedsesametherapy.com/'
     },
-    "hasOfferCatalog": {
-      "@type": "OfferCatalog",
-      "name": "Therapy Approaches",
-      "itemListElement": ourApproachData.map(service => ({
-        "@type": "Offer",
-        "itemOffered": {
-          "@type": "Service",
-          "name": service.title,
-          "description": service.description
+    hasOfferCatalog: {
+      '@type': 'OfferCatalog',
+      name: 'Therapy Approaches',
+      itemListElement: ourApproachData.map(s => ({
+        '@type': 'Offer',
+        itemOffered: {
+          '@type': 'Service',
+          name: s.title,
+          description: s.description
         }
       }))
     }
   };
 
+  const jsonLd = {
+    '@context': 'https://schema.org',
+    '@graph': [
+      {
+        '@type': 'BreadcrumbList',
+        itemListElement: [
+          { '@type': 'ListItem', position: 1, name: 'Home', item: 'https://toastedsesametherapy.com/' },
+          { '@type': 'ListItem', position: 2, name: 'Therapy Services', item: canonical }
+        ]
+      },
+      {
+        '@type': 'Organization',
+        name: 'Toasted Sesame Therapy',
+        url: 'https://toastedsesametherapy.com/'
+      },
+      serviceSchema,
+      faqSchema
+    ]
+  };
+
   return (
     <>
-      {/* Add the schema script here */}
-      <script
-        type="application/ld+json"
-        dangerouslySetInnerHTML={{ __html: JSON.stringify(faqSchema) }}
-      />
-<script
-        type="application/ld+json"
-        dangerouslySetInnerHTML={{ __html: JSON.stringify(serviceSchema) }}
-      />
-      {/* Render the client component */}
+      <Script id="services-jsonld" type="application/ld+json" dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }} />
       <ServicesPageClient />
     </>
   );

--- a/src/components/clients/AboutPageClient/AboutPageClient.tsx
+++ b/src/components/clients/AboutPageClient/AboutPageClient.tsx
@@ -15,8 +15,8 @@ import type { Metadata } from 'next';
 import Image from "next/image";
 
 export const metadata: Metadata = {
-  title: 'About Kay | Toasted Sesame Therapy',
-  description: 'Meet Kay (she/they), a Korean American, queer, and neurodivergent therapist dedicated to providing identity-centered care.'
+  title: 'About Kay — Queer- and Asian-Owned Therapy Practice in Atlanta',
+  description: 'Meet Kay (she/they), a licensed therapist providing affirming, identity-centered care for queer, neurodivergent, and trauma-impacted clients across Georgia.'
 };
 
 const containerVariants = {

--- a/src/components/clients/ContactPageClient/ContactPageClient.tsx
+++ b/src/components/clients/ContactPageClient/ContactPageClient.tsx
@@ -53,13 +53,19 @@ const ContactPageClient = () => {
             <div className="text-center">
               <motion.h1
                 variants={itemVariants}
-                className="text-4xl md:text-5xl lg:text-6xl font-extrabold mb-8 leading-tight max-w-5xl mx-auto"
+                className="text-3xl md:text-4xl lg:text-5xl font-extrabold mb-8 leading-tight max-w-5xl mx-auto"
               >
                 {heroContent.title}
               </motion.h1>
               <motion.p
                 variants={itemVariants}
-                className="text-xl md:text-2xl text-gray-700 max-w-3xl mx-auto mb-12 leading-relaxed"
+                className="text-xl md:text-4xl lg:text-2xl font-semibold leading-tight max-w-5xl mx-auto"
+              >
+                {heroContent.title2}
+              </motion.p>
+              <motion.p
+                variants={itemVariants}
+                className="text-md md:text-xl text-gray-700 max-w-3xl mx-auto mb-12 leading-relaxed"
               >
                 {heroContent.subtitle}
               </motion.p>

--- a/src/components/clients/HomePageClient/HomePageClient.tsx
+++ b/src/components/clients/HomePageClient/HomePageClient.tsx
@@ -1,0 +1,420 @@
+"use client";
+
+import { motion, useInView } from "framer-motion";
+import { useRef } from "react";
+import { useRouter } from 'next/navigation';
+import dynamic from 'next/dynamic';
+import Section from "@/components/Section/Section";
+import TestimonialCard from "@/components/TestimonialCard/TestimonialCard";
+import Image from "next/image";
+import Button from "@/components/Button/Button";
+import CircleIcon from "@/components/CircleIcon/CircleIcon";
+import AnimatedCheckbox from "@/components/AnimatedCheckbox/AnimatedCheckbox";
+import ProfileImage from "@/components/ProfileImage/ProfileImage";
+import HoverLink from '@/components/HoverLink/HoverLink';
+import { LottiePlayer } from "@/components/LottiePlayer/LottiePlayer";
+import {tiredAnimation} from "@/data/animations";
+import {
+  socialProofIcons,
+  testimonials,
+  checklistItems,
+  meetYourTherapist,
+  howItWorksSteps,
+  trustIndicators,
+} from "@/data/pageData";
+import ContactForm from "@/components/Contact/ContactForm";
+
+const TherapyCard = dynamic(() => import("@/components/TherapyCard/TherapyCard"), {
+  loading: () => (
+    <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-8">
+      {[...Array(4)].map((_, i) => (
+        <div key={i} className="animate-pulse bg-gray-200 rounded-lg h-64 border-2 border-black"></div>
+      ))}
+    </div>
+  ),
+});
+
+const HowItWorksStep = dynamic(() => import("@/components/HowItWorksSteps/HowItWorksSteps"), {
+  loading: () => (
+    <div className="animate-pulse bg-gray-200 rounded-lg h-48 border-2 border-black"></div>
+  ),
+});
+
+const LeadMagnet = dynamic(() => import("@/components/LeadMagnet/LeadMagnet"), {
+  loading: () => (
+    <div className="animate-pulse bg-gray-200 rounded-lg h-96 border-2 border-black"></div>
+  ),
+});
+
+
+// Animation variants
+const heroContainerVariants = {
+  hidden: { opacity: 0 },
+  visible: {
+    opacity: 1,
+    transition: { staggerChildren: 0.07 },
+  },
+};
+
+const heroItemVariants = {
+  hidden: { y: 50, opacity: 0 },
+  visible: {
+    y: 0,
+    opacity: 1,
+    transition: { duration: 0.4 },
+  },
+};
+
+const containerVariants = {
+  hidden: { opacity: 0 },
+  visible: {
+    opacity: 1,
+    transition: { staggerChildren: 0.1, delayChildren: 0.1 },
+  },
+};
+
+const itemVariants = {
+  hidden: { y: 20, opacity: 0 },
+  visible: {
+    y: 0,
+    opacity: 1,
+    transition: { duration: 0.5 },
+  },
+};
+
+const sectionVariants = {
+  hidden: { opacity: 0 },
+  visible: {
+    opacity: 1,
+    transition: { duration: 0.5 },
+  },
+};
+
+// Component for the tired animation section
+const TiredAnimationSection = ({width, height}) => {
+  return (
+    <div className="w-full h-full">
+      <LottiePlayer
+        file={tiredAnimation}
+        width={width}
+        height={height}
+        loop={true}
+        autoplay={true}
+        speed={1}
+        alt=""
+      />
+    </div>
+  );
+};
+
+export default function HomePageClient() {
+  const howItWorksRef = useRef(null);
+
+  // Create individual refs for each step
+  const step0Ref = useRef<HTMLDivElement>(null);
+  const step1Ref = useRef<HTMLDivElement>(null);
+  const step2Ref = useRef<HTMLDivElement>(null);
+  const step3Ref = useRef<HTMLDivElement>(null);
+
+  // Track which steps are in view using individual refs
+  const step0InView = useInView(step0Ref, { once: true, amount: 0.5 });
+  const step1InView = useInView(step1Ref, { once: true, amount: 0.5 });
+  const step2InView = useInView(step2Ref, { once: true, amount: 0.5 });
+  const step3InView = useInView(step3Ref, { once: true, amount: 0.5 });
+
+  // Create array of step visibility states
+  const stepInViewStates = [step0InView, step1InView, step2InView, step3InView];
+
+  // Create array of refs for easy access in the map
+  const stepRefs = [step0Ref, step1Ref, step2Ref, step3Ref];
+
+  const handleScroll = (e: React.MouseEvent<HTMLButtonElement>) => {
+    e.preventDefault();
+    const contactForm = document.getElementById("contact-form");
+    if (contactForm) {
+      contactForm.scrollIntoView({
+        behavior: "smooth",
+        block: "start",
+      });
+    }
+  };
+
+  const router = useRouter();
+
+  const handleResourcesClick = () => {
+    router.push('/guides');
+  };
+
+  return (
+    <main>
+      <Section className="pb-32" minHeight="100vh">
+        <motion.div
+          className="grid grid-cols-1 md:grid-cols-2 gap-16 items-center min-h-500"
+          variants={heroContainerVariants}
+          initial="hidden"
+          animate="visible"
+        >
+          <motion.div
+            className="flex flex-col gap-4"
+            variants={heroContainerVariants}
+          >
+           <motion.div variants={heroItemVariants}>
+  <Image
+    src="https://pvbdrbaquwivhylsmagn.supabase.co/storage/v1/object/public/tst-assets/logo/tst-logo-long-baseline.svg"
+    alt="Tst Logo"
+    width={600}
+    height={600}
+  />
+</motion.div>
+            <motion.h1
+              className="text-5xl lg:text-6xl font-extrabold leading-tight"
+              variants={heroItemVariants}
+            >
+              For the deep feelers, drained hearts, and healing seekers.
+            </motion.h1>
+            <motion.p className="text-lg" variants={heroItemVariants}>
+              You&apos;ve carried too much for too long. It&apos;s time to finally care
+              for you.
+            </motion.p>
+
+            <motion.div
+              className="flex flex-col md:flex-row flex-wrap gap-4 pt-4"
+              variants={heroItemVariants}
+            >
+              <Button onClick={handleScroll} className="bg-tst-yellow" id="book-a-call-btn">
+                Book a call
+              </Button>
+              <Button onClick={handleResourcesClick} className="bg-white" id="download-free-guides-btn">
+               Download Your Free Guides
+              </Button>
+            </motion.div>
+<motion.div
+  className="flex flex-row gap-4 flex-wrap justify-center md:justify-start"
+  variants={heroItemVariants}
+>
+  {trustIndicators.map((indicator) => (
+    <div key={indicator.id} className="flex items-center gap-3">
+      <CircleIcon
+        size="xs"
+        bgColor="bg-green-100"
+        iconUrl={indicator.iconUrl}
+      />
+      <span className="font-bold">{indicator.text}</span>
+    </div>
+  ))}
+</motion.div>
+            <motion.div
+              className="pt-6 flex flex-col items-center text-center md:flex-row md:items-start md:text-left gap-4"
+              variants={heroItemVariants}
+            >
+              <div className="flex flex-shrink-0">
+                {socialProofIcons.map((icon, index) => (
+                  <CircleIcon
+                    key={index}
+                    size="sm"
+                    bgColor={icon.bgColor}
+                    iconUrl={icon.iconUrl}
+                    altText={icon.altText}
+                    wrapperClassName={icon.className}
+                  />
+                ))}
+              </div>
+              <p className="text-sm font-medium">
+                <strong>More than 200+ people</strong> have taken the first
+                step.
+                <br />
+                You&apos;re not alone.
+              </p>
+            </motion.div>
+          </motion.div>
+
+          <motion.div
+            className="flex items-center justify-center"
+            variants={heroItemVariants}
+          >
+            <Image
+              src="https://pvbdrbaquwivhylsmagn.supabase.co/storage/v1/object/public/tst-assets/website%20assets/Hero%20Bean%20Bun.png"
+              alt="Therapy illustration"
+              width={600}
+              height={600}
+              className="w-full h-auto max-w-xl mx-auto"
+              priority
+            />
+          </motion.div>
+        </motion.div>
+
+        <motion.div
+          className="grid grid-cols-1 md:grid-cols-3 gap-y-12 md:gap-x-8 mt-16"
+          variants={containerVariants}
+          initial="hidden"
+          whileInView="visible"
+          viewport={{ once: true, amount: 0.2 }}
+        >
+          {testimonials.map((testimonial, index) => (
+            <motion.div key={index} variants={itemVariants}>
+              <TestimonialCard
+                quote={testimonial.quote}
+                iconUrl={testimonial.iconUrl}
+                bgColor={testimonial.bgColor}
+                altText={testimonial.altText}
+              />
+            </motion.div>
+          ))}
+        </motion.div>
+        <motion.p
+          className="text-center italic mt-16 max-w-2xl mx-auto"
+          variants={sectionVariants}
+          initial="hidden"
+          whileInView="visible"
+          viewport={{ once: true, amount: 0.2 }}
+        >
+          Each reflection is based on real things clients have shared,
+          thoughtfully paraphrased to honor both their meaning and their
+          privacy.
+        </motion.p>
+      </Section>
+
+      <div className="border-t-2 border-black">
+        <Section className="bg-tst-yellow" minHeight="750px">
+          <motion.div
+            className="bg-white border-2 border-black rounded-xl shadow-brutalistLg p-8 md:p-12"
+            variants={sectionVariants}
+            initial="hidden"
+            whileInView="visible"
+            viewport={{ once: true, amount: 0.2 }}
+          >
+            <div className="grid md:grid-cols-2 gap-8 items-center">
+              <div className="flex flex-col gap-6">
+                <h2 className="text-4xl md:text-5xl font-extrabold">
+                  Check all that sound like you.
+                </h2>
+
+                <div className="block md:hidden w-56 mx-auto aspect-square">
+                  <TiredAnimationSection width={200} height={200}/>
+                </div>
+
+              <div className="flex flex-col gap-4">
+                {checklistItems.map((item) => (
+                <AnimatedCheckbox key={item.id} id={item.id} label={item.label} />
+                ))}
+                </div>
+                <div className="pt-4">
+                  <Button onClick={handleScroll} className="bg-tst-purple" id="checkbox-get-started-btn">
+                    Get Started
+                  </Button>
+                </div>
+              </div>
+
+              <div className="hidden md:block max-w-sm mx-auto aspect-square">
+                <TiredAnimationSection width={400} height={400}/>
+              </div>
+            </div>
+
+          </motion.div>
+        </Section>
+      </div>
+
+      <div className="border-t-2 border-black">
+        <LeadMagnet />
+      </div>
+
+      <div className="border-t-2 border-black">
+        <Section className="bg-tst-purple" minHeight="1000px">
+          <motion.div
+            className="text-center mb-12"
+            variants={sectionVariants}
+            initial="hidden"
+            whileInView="visible"
+            viewport={{ once: true, amount: 0.2 }}
+          >
+            <h2 className="text-5xl font-extrabold">
+              Therapy that actually gets you
+            </h2>
+          </motion.div>
+          <TherapyCard />
+        </Section>
+      </div>
+
+      <div>
+        <Section minHeight="400px" className="border-t-2 border-black">
+          <motion.div
+            className="grid md:grid-cols-2 gap-12 md:gap-16 items-center min-h-400"
+            variants={sectionVariants}
+            initial="hidden"
+            whileInView="visible"
+            viewport={{ once: true, amount: 0.2 }}
+          >
+            <div className="flex justify-center">
+              <ProfileImage />
+            </div>
+
+            <motion.div
+              className="flex flex-col gap-4"
+              variants={containerVariants}
+            >
+              <motion.h2
+                className="text-5xl font-extrabold"
+                variants={itemVariants}
+              >
+                {meetYourTherapist.title}
+              </motion.h2>
+              {meetYourTherapist.paragraphs.map((text, index) => (
+                <motion.p
+                  key={index}
+                  className="text-lg"
+                  variants={itemVariants}
+                >
+                  {text}
+                </motion.p>
+              ))}
+              <motion.div variants={itemVariants} className="relative">
+  <div className="absolute left-0" style={{ marginLeft: '-22px' }}>
+    <HoverLink href="/about" className="group gap-2 font-bold text-lg text-tst-purple">
+      <span>Read my full bio</span>
+    </HoverLink>
+  </div>
+</motion.div>
+            </motion.div>
+          </motion.div>
+        </Section>
+      </div>
+
+      <div ref={howItWorksRef}>
+        <Section minHeight="1000px">
+          <motion.div
+            className="text-center mb-12"
+            initial={{ opacity: 0 }}
+            whileInView={{ opacity: 1 }}
+            viewport={{ once: true, amount: 0.5 }}
+            transition={{ duration: 0.5 }}
+          >
+            <h2 className="text-6xl font-extrabold">
+              What working together looks like
+            </h2>
+          </motion.div>
+          <div className="flex flex-col min-h-1000">
+            {howItWorksSteps.map((step, index) => {
+              const currentRef = stepRefs[index];
+              const nextStepInView = index < howItWorksSteps.length - 1 ? stepInViewStates[index + 1] : false;
+
+              return (
+                <div key={index} ref={currentRef}>
+                  <HowItWorksStep
+                    step={step}
+                    index={index}
+                    isLastStep={step.isLastStep}
+                    nextStepInView={nextStepInView}
+                  />
+                </div>
+              );
+            })}
+          </div>
+        </Section>
+      </div>
+
+      <Section>
+        <ContactForm id="contact-form"/>
+      </Section>
+    </main>
+  );
+}

--- a/src/components/clients/ServicesPageClient/ServicesPageClient.tsx
+++ b/src/components/clients/ServicesPageClient/ServicesPageClient.tsx
@@ -32,18 +32,10 @@ const itemVariants = {
 };
 
 const ServicesPageClient = () => {
-  const pathname = usePathname();
   const router = useRouter();
 
   const handleClick = () => {
-    if (pathname === "/") {
-      const contactForm = document.getElementById("contact-form");
-      if (contactForm) {
-        contactForm.scrollIntoView({ behavior: "smooth" });
-      }
-    } else {
-      router.push("/#contact-form");
-    }
+    router.push("/contact");
   };
 
   return (
@@ -57,11 +49,11 @@ const ServicesPageClient = () => {
             animate="visible"
         >
           <motion.div
-            className="text-center max-w-4xl mx-auto flex flex-col gap-6 items-center"
+            className="text-center max-w-4xl mx-auto flex flex-col gap-5 items-center"
             variants={itemVariants}
            >
             <h1 className="text-5xl lg:text-6xl font-extrabold">
-              Therapy That Fits You, As You Are.
+              Therapy That Fits You, As You Are: Virtual Therapy Across Georgia
             </h1>
             <p className="text-lg">
               Explore our therapeutic approach and find the support that meets
@@ -76,7 +68,7 @@ const ServicesPageClient = () => {
           </motion.div>
 
           <motion.div
-            className="w-full max-w-5xl mx-auto mt-16"
+            className="w-full max-w-5xl mx-auto mt-10"
             variants={itemVariants}
           >
             <FallingPills/>

--- a/src/components/clients/ServicesPageClient/ServicesPageClient.tsx
+++ b/src/components/clients/ServicesPageClient/ServicesPageClient.tsx
@@ -2,7 +2,7 @@
 
 import React from "react";
 import { motion } from "framer-motion";
-import { usePathname, useRouter } from "next/navigation";
+import { useRouter } from "next/navigation";
 import Section from "@/components/Section/Section";
 import Button from "@/components/Button/Button";
 import FAQ from "@/components/FAQ/FAQ";

--- a/src/data/aboutData.ts
+++ b/src/data/aboutData.ts
@@ -1,7 +1,7 @@
 // src/data/aboutData.ts
 
 export const aboutPageContent = {
-  title: "About Me",
+  title: "Meet Kay, a therapist for the ones who hold it all",
   paragraphs: [
     "The people I work with often carry more than anyone realizes. They’re the ones others lean on, the ones who rarely have space to fall apart.",
     "I'm Kay (she/they), a Korean American, queer, neurodivergent therapist living with CPTSD.",
@@ -13,4 +13,3 @@ export const aboutPageContent = {
     "If this feels like a space you’ve been looking for, I would be honored to connect with you.",
   ],
 };
-

--- a/src/data/contactData.ts
+++ b/src/data/contactData.ts
@@ -1,23 +1,27 @@
 // src/data/contactData.ts
 
+
 export const trustIndicators = [
   {
     id: 1,
-    text: "Phone and Video",
-    iconUrl: "https://pvbdrbaquwivhylsmagn.supabase.co/storage/v1/object/public/tst-assets/website%20assets/checkmark.svg",
-    altText: "",
+    text: "Phone or Video",
+    iconUrl:
+      "https://pvbdrbaquwivhylsmagn.supabase.co/storage/v1/object/public/tst-assets/website%20assets/checkmark.svg",
+    altText: "Sessions by phone or video",
   },
   {
     id: 2,
-    text: "No waitlist",
-    iconUrl: "https://pvbdrbaquwivhylsmagn.supabase.co/storage/v1/object/public/tst-assets/website%20assets/checkmark.svg",
-    altText: "",
+    text: "No Waitlist",
+    iconUrl:
+      "https://pvbdrbaquwivhylsmagn.supabase.co/storage/v1/object/public/tst-assets/website%20assets/checkmark.svg",
+    altText: "No waitlist indicator",
   },
   {
     id: 3,
-    text: "11 A.M. to 5 P.M.",
-    iconUrl: "https://pvbdrbaquwivhylsmagn.supabase.co/storage/v1/object/public/tst-assets/website%20assets/checkmark.svg",
-    altText: "",
+    text: "11 AM–5 PM ET",
+    iconUrl:
+      "https://pvbdrbaquwivhylsmagn.supabase.co/storage/v1/object/public/tst-assets/website%20assets/checkmark.svg",
+    altText: "Office hours 11 AM to 5 PM Eastern",
   },
 ];
 
@@ -50,9 +54,15 @@ export const benefitCards = [
 
 export const heroContent = {
   badge: "Your First Step Towards Clarity",
-  title: "A Space to Be Seen and Heard",
-  subtitle: "Reaching out is an act of courage. I'm here to meet you with warmth and understanding. Let's schedule a free, no-pressure chat to see how I can support you.",
+  // SEO-focused, exact-match headline:
+  title: "Book a Consultation with Atlanta’s First Queer and Asian-Owned Therapy Practice",
+  title2: "Your Space to Be Seen and Heard",
+  subtitle:
+    "Atlanta, GA • Virtual therapy across Georgia. I’m Kay (she/they), a queer Korean American therapist. Schedule a free, no‑pressure 15‑minute consultation.",
+  // New: a short location line you can render under the hero
+  locationLine: "Atlanta, GA • Virtual therapy across Georgia",
 };
+
 
 export const benefitsSection = {
   title: "A Different Kind of Therapy Experience",


### PR DESCRIPTION
### Changes
- Update `contactData.ts`:
  - Hero title now exact-match: “Book a Consultation — Queer Asian Therapist in Atlanta”
  - Add `locationLine` and refine subtitle for Atlanta/Georgia telehealth
  - Normalize trust indicators and add `altText`
- `ContactPageClient`:
  - Render SEO H1 and location line from data
  - Add accessible, clickable arrow that scrolls to `#contact-form`
  - Ensure consistent `id="contact-form"` on both mobile and desktop forms
  - Pass alt text to icons or keep icons decorative with proper aria

### Why
- Exact-match query in the H1 and early copy improves topical relevance
- Location line strengthens local SEO signals
- Accessibility and UX improvements increase form completion

### Next
- Keep `contact/page.tsx` metadata + JSON-LD changes from earlier PR
- Consider a GA4 event (`scroll_to_contact_form`) as a secondary metric