### PR TITLE
feat(seo): update booking page SEO and rebrand to fit-or-free sessions

### DIFF
--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,0 +1,27 @@
+User-agent: *
+Allow: /
+
+# High priority pages for crawling
+Allow: /book
+Allow: /book/affirming  
+Allow: /book/nd
+Allow: /book/trauma
+Allow: /therapy-services
+Allow: /about
+Allow: /contact
+Allow: /mental-health-healing-blog
+Allow: /guides
+
+# Block admin/dashboard areas
+Disallow: /dashboard
+Disallow: /login
+Disallow: /reschedule
+Disallow: /cancel-appointment
+Disallow: /thank-you
+Disallow: /thank-you-reschedule
+
+# Block API endpoints
+Disallow: /api/
+
+# Sitemap
+Sitemap: https://toastedsesametherapy.com/sitemap.xml

--- a/src/app/book/affirming/page.tsx
+++ b/src/app/book/affirming/page.tsx
@@ -5,9 +5,9 @@ import UnifiedBookingFlow from '@/components/TwoStepBooking/UnifiedBookingFlow';
 import AdditionalContent from '../AdditionalContent';
 
 export const metadata: Metadata = {
-  title: 'LGBTQIA-Affirming Free Grounding Plan Session | Kay Therapy',
+  title: 'LGBTQIA-Affirming Free Consultation + Fit-or-Free Sessions | Kay Therapy',
   description:
-    'Free 15-minute grounding plan session in a safe, LGBTQIA-affirming space. Mental health strategies that honor your identity. Licensed therapist in Georgia.',
+    'Free 15-minute consultation in a safe, LGBTQIA-affirming space. If your first session isn\'t a good fit, it\'s completely free. Mental health strategies that honor your identity. Licensed therapist in Georgia.',
   keywords: [
     'LGBTQIA therapy',
     'queer therapy',
@@ -23,9 +23,9 @@ export const metadata: Metadata = {
     'free consultation',
   ],
   openGraph: {
-    title: 'LGBTQIA-Affirming Free Grounding Plan Session',
+    title: 'LGBTQIA-Affirming Free Consultation + Fit-or-Free Sessions',
     description:
-      'A safe space where your identity is celebrated. Free 15-minute session with Georgia-licensed, LGBTQIA-affirming therapist.',
+      'A safe space where your identity is celebrated. Free 15-minute consultation with Georgia-licensed, LGBTQIA-affirming therapist, plus fit-or-free therapy sessions.',
     type: 'website',
     locale: 'en_US',
   },
@@ -46,7 +46,7 @@ export default function AffirmingBookingPage() {
           <UnifiedBookingFlow variant="affirming" />
         </div>
       </Section>
-      
+
       {/* Additional content below the fold */}
       <AdditionalContent />
     </div>

--- a/src/app/book/nd/page.tsx
+++ b/src/app/book/nd/page.tsx
@@ -5,9 +5,9 @@ import UnifiedBookingFlow from '@/components/TwoStepBooking/UnifiedBookingFlow';
 import AdditionalContent from '../AdditionalContent';
 
 export const metadata: Metadata = {
-  title: 'Neurodivergent-Friendly Free Grounding Plan Session | Kay Therapy',
+  title: 'Neurodivergent-Friendly Free Consultation + Fit-or-Free Sessions | Kay Therapy',
   description:
-    'Free 15-minute grounding plan session designed specifically for neurodivergent adults. Get practical, sensory-aware coping strategies that work with your brain. Licensed therapist in Georgia.',
+    'Free 15-minute consultation designed specifically for neurodivergent adults. If your first session isn\'t a good fit, it\'s completely free. Get practical, sensory-aware coping strategies that work with your brain. Licensed therapist in Georgia.',
   keywords: [
     'neurodivergent therapy',
     'ADHD coping strategies',
@@ -21,9 +21,9 @@ export const metadata: Metadata = {
     'free consultation',
   ],
   openGraph: {
-    title: 'Neurodivergent-Friendly Free Grounding Plan Session',
+    title: 'Neurodivergent-Friendly Free Consultation + Fit-or-Free Sessions',
     description:
-      'Practical, sensory-aware coping strategies designed for neurodivergent brains. Free 15-minute session with Georgia-licensed therapist.',
+      'Practical, sensory-aware coping strategies designed for neurodivergent brains. Free 15-minute consultation with Georgia-licensed therapist, plus fit-or-free therapy sessions.',
     type: 'website',
     locale: 'en_US',
   },
@@ -44,7 +44,7 @@ export default function NeurodivergentBookingPage() {
           <UnifiedBookingFlow variant="nd" />
         </div>
       </Section>
-      
+
       {/* Additional content below the fold */}
       <AdditionalContent />
     </div>

--- a/src/app/book/page.tsx
+++ b/src/app/book/page.tsx
@@ -5,13 +5,14 @@ import UnifiedBookingFlow from '@/components/TwoStepBooking/UnifiedBookingFlow';
 import AdditionalContent from './AdditionalContent';
 
 export const metadata: Metadata = {
-  title: 'Free Grounding Plan Session | Kay Therapy',
+  title: 'Free 15-Minute Consultation + Fit-or-Free Sessions | Kay Therapy',
   description:
-    'Free 15-minute grounding plan session with a licensed therapist in Georgia. Get personalized coping strategies that work for you.',
+    'Free 15-minute consultation with a licensed therapist in Georgia. After your consultation, book fit-or-free therapy sessions - if they\'re not a good fit, they\'re completely free. Get personalized coping strategies that work for you.',
   keywords: [
     'therapy',
     'free consultation',
-    'grounding techniques',
+    'fit-or-free session',
+    'risk-free therapy',
     'coping strategies',
     'mental health',
     'Atlanta therapist',
@@ -19,9 +20,9 @@ export const metadata: Metadata = {
     'stress management',
   ],
   openGraph: {
-    title: 'Free Grounding Plan Session',
+    title: 'Free 15-Minute Consultation + Fit-or-Free Sessions',
     description:
-      'Get personalized coping strategies in a free 15-minute session with a Georgia-licensed therapist.',
+      'Free 15-minute consultation plus fit-or-free therapy sessions with a Georgia-licensed therapist. If therapy sessions aren\'t a good fit, they\'re completely free.',
     type: 'website',
     locale: 'en_US',
   },
@@ -42,7 +43,7 @@ export default function BookingPage() {
           <UnifiedBookingFlow variant="trauma" />
         </div>
       </Section>
-      
+
       {/* Additional content below the fold */}
       <AdditionalContent />
     </div>

--- a/src/app/book/trauma/page.tsx
+++ b/src/app/book/trauma/page.tsx
@@ -5,9 +5,9 @@ import UnifiedBookingFlow from '@/components/TwoStepBooking/UnifiedBookingFlow';
 import AdditionalContent from '../AdditionalContent';
 
 export const metadata: Metadata = {
-  title: 'Free Grounding Plan Session for Georgia Adults | Kay Therapy',
+  title: 'Free Consultation + Fit-or-Free Sessions for Georgia Adults | Kay Therapy',
   description:
-    'Free 15-minute grounding plan session with trauma-informed approaches. Feel safe and grounded even when life feels overwhelming. Licensed therapist in Georgia.',
+    'Free 15-minute consultation with trauma-informed approaches. If your first session isn\'t a good fit, it\'s completely free. Feel safe and grounded even when life feels overwhelming. Licensed therapist in Georgia.',
   keywords: [
     'trauma therapy',
     'trauma-informed therapy',
@@ -22,9 +22,9 @@ export const metadata: Metadata = {
     'free consultation',
   ],
   openGraph: {
-    title: 'Free Grounding Plan Session for Georgia Adults',
+    title: 'Free Consultation + Fit-or-Free Sessions for Georgia Adults',
     description:
-      'Trauma-informed grounding strategies to help you feel safe when life feels overwhelming. Free 15-minute session.',
+      'Trauma-informed strategies to help you feel safe when life feels overwhelming. Free 15-minute consultation plus fit-or-free therapy sessions.',
     type: 'website',
     locale: 'en_US',
   },
@@ -45,7 +45,7 @@ export default function TraumaBookingPage() {
           <UnifiedBookingFlow variant="trauma" />
         </div>
       </Section>
-      
+
       {/* Additional content below the fold */}
       <AdditionalContent />
     </div>

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -86,6 +86,31 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
       changeFrequency: 'weekly',
       priority: 0.85,
     },
+    // Booking pages - high priority for conversions
+    {
+      url: `${baseUrl}/book`,
+      lastModified: nowIso,
+      changeFrequency: 'monthly',
+      priority: 0.95,
+    },
+    {
+      url: `${baseUrl}/book/affirming`,
+      lastModified: nowIso,
+      changeFrequency: 'monthly',
+      priority: 0.9,
+    },
+    {
+      url: `${baseUrl}/book/nd`,
+      lastModified: nowIso,
+      changeFrequency: 'monthly',
+      priority: 0.9,
+    },
+    {
+      url: `${baseUrl}/book/trauma`,
+      lastModified: nowIso,
+      changeFrequency: 'monthly',
+      priority: 0.9,
+    },
     {
       url: `${baseUrl}/policy`,
       lastModified: nowIso,


### PR DESCRIPTION
- Update all booking page metadata with clearer language
- Distinguish between free 15-min consultation vs fit-or-free therapy sessions
- Add booking pages to sitemap with high priority (0.9-0.95)
- Create comprehensive robots.txt for better crawl guidance
- Update terminology from "grounding sessions" to "fit-or-free sessions"
- Improve meta descriptions to emphasize risk-free value proposition

🤖 Generated with [Claude Code](https://claude.ai/code)