### PR TITLE
feat: add business queries page with Resend email integration

### DIFF
--- a/src/app/api/business-query/route.ts
+++ b/src/app/api/business-query/route.ts
@@ -1,0 +1,113 @@
+/**
+ * API route for business query email sending
+ * Uses Resend to send business inquiries to kato@toastedsesametherapy.com
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import { Resend } from 'resend';
+
+const RESEND_API_KEY = process.env.RESEND_API_KEY!;
+const EMAIL_FROM = process.env.EMAIL_FROM || 'Toasted Sesame <kato@toastedsesametherapy.com>';
+const BUSINESS_EMAIL = 'kato@toastedsesametherapy.com';
+
+interface BusinessQueryRequest {
+  name: string;
+  email: string;
+  phone: string;
+  queryType: string;
+}
+
+function getBusinessQueryEmailTemplate(data: BusinessQueryRequest): string {
+  const { name, email, phone, queryType } = data;
+  
+  return `
+    <div style="font-family: Arial, sans-serif; max-width: 600px; margin: 0 auto; padding: 20px;">
+      <div style="background-color: #F9F5F2; border: 2px solid #000; border-radius: 12px; padding: 30px; margin-bottom: 20px;">
+        <h1 style="color: #000; margin: 0 0 20px 0; font-size: 28px; font-weight: bold;">New Business Query</h1>
+        
+        <div style="background-color: #F7BD01; border: 2px solid #000; border-radius: 8px; padding: 20px; margin-bottom: 20px;">
+          <h2 style="margin: 0 0 10px 0; font-size: 20px; color: #000;">Query Type: ${queryType}</h2>
+        </div>
+
+        <div style="background-color: #fff; border: 2px solid #000; border-radius: 8px; padding: 20px; margin-bottom: 15px;">
+          <h3 style="margin: 0 0 15px 0; color: #000; font-size: 18px;">Contact Information</h3>
+          <p style="margin: 5px 0; font-size: 16px; color: #000;"><strong>Name:</strong> ${name}</p>
+          <p style="margin: 5px 0; font-size: 16px; color: #000;"><strong>Email:</strong> ${email}</p>
+          <p style="margin: 5px 0; font-size: 16px; color: #000;"><strong>Phone:</strong> ${phone}</p>
+        </div>
+
+        <div style="background-color: #C5A1FF; border: 2px solid #000; border-radius: 8px; padding: 15px; text-align: center;">
+          <p style="margin: 0; font-size: 14px; color: #000;">
+            This business query was submitted on ${new Date().toLocaleDateString('en-US', { 
+              weekday: 'long', 
+              year: 'numeric', 
+              month: 'long', 
+              day: 'numeric',
+              hour: 'numeric',
+              minute: '2-digit',
+              timeZone: 'America/New_York',
+              timeZoneName: 'short'
+            })}
+          </p>
+        </div>
+      </div>
+    </div>
+  `;
+}
+
+export async function POST(request: NextRequest): Promise<NextResponse> {
+  try {
+    if (!RESEND_API_KEY) {
+      console.error('❌ RESEND_API_KEY not configured');
+      return NextResponse.json({ error: 'RESEND_API_KEY not configured' }, { status: 500 });
+    }
+
+    const body: BusinessQueryRequest = await request.json();
+    const { name, email, phone, queryType } = body;
+
+    if (!name || !email || !phone || !queryType) {
+      return NextResponse.json({ error: 'Missing required fields' }, { status: 400 });
+    }
+
+    const resend = new Resend(RESEND_API_KEY);
+
+    const html = getBusinessQueryEmailTemplate({ name, email, phone, queryType });
+    const subject = `Business Query: ${queryType} - ${name}`;
+
+    const result = await resend.emails.send({
+      from: EMAIL_FROM,
+      to: BUSINESS_EMAIL,
+      subject,
+      html,
+    });
+
+    if ((result as any)?.error) {
+      console.error('❌ Failed to send business query email:', (result as any).error);
+      return NextResponse.json(
+        { error: `Failed to send email: ${JSON.stringify((result as any).error)}` }, 
+        { status: 500 }
+      );
+    }
+
+    console.log('✅ Business query email sent successfully:', { name, email, queryType });
+
+    return NextResponse.json({ success: true, message: 'Business query submitted successfully' });
+
+  } catch (error) {
+    console.error('Failed to send business query email:', error);
+    const msg = error instanceof Error ? error.message : 'Unknown error';
+    return NextResponse.json({ success: false, error: msg }, { status: 500 });
+  }
+}
+
+export async function GET() { 
+  return NextResponse.json({ error: 'Method not allowed' }, { status: 405 }); 
+}
+
+export async function PUT() { 
+  return NextResponse.json({ error: 'Method not allowed' }, { status: 405 }); 
+}
+
+export async function DELETE() { 
+  return NextResponse.json({ error: 'Method not allowed' }, { status: 405 }); 
+}

--- a/src/app/business-queries/page.tsx
+++ b/src/app/business-queries/page.tsx
@@ -1,0 +1,230 @@
+'use client';
+
+import React, { useState, useEffect } from 'react';
+import Link from 'next/link';
+import Confetti from 'react-confetti';
+import Button from '@/components/Button/Button';
+import Input from '@/components/Input/Input';
+import { formatPhoneNumber } from '@/lib/validation';
+
+const useWindowSize = () => {
+  const [size, setSize] = useState({ width: 0, height: 0 });
+  useEffect(() => {
+    const handleResize = () =>
+      setSize({ width: window.innerWidth, height: window.innerHeight });
+    handleResize();
+    window.addEventListener('resize', handleResize);
+    return () => window.removeEventListener('resize', handleResize);
+  }, []);
+  return size;
+};
+
+const BusinessQueriesPage: React.FC = () => {
+  const [formData, setFormData] = useState({
+    name: '',
+    email: '',
+    phone: '',
+    queryType: ''
+  });
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [isSubmitted, setIsSubmitted] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const { width, height } = useWindowSize();
+
+  const queryOptions = [
+    { value: '', label: 'Select query type' },
+    { value: 'referrals', label: 'Referrals' },
+    { value: 'collaboration', label: 'Collaboration Opportunities' },
+    { value: 'consultation', label: 'Professional Consultation' },
+    { value: 'training', label: 'Training/Workshop Inquiries' },
+    { value: 'media', label: 'Media/Press Inquiries' },
+    { value: 'other', label: 'Other Business Inquiry' }
+  ];
+
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement | HTMLSelectElement>) => {
+    const { name, value } = e.target;
+
+    if (name === 'phone') {
+      const formattedValue = formatPhoneNumber(value);
+      if (formattedValue === 'INVALID_COUNTRY_CODE') {
+        setError('Only US phone numbers are supported. Please remove international country codes except +1.');
+        return;
+      }
+      setFormData({ ...formData, [name]: formattedValue });
+    } else {
+      setFormData({ ...formData, [name]: value });
+    }
+
+    // Clear error when user starts typing
+    if (error) setError(null);
+  };
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+
+    if (!formData.queryType) {
+      setError('Please select a query type');
+      return;
+    }
+
+    setIsSubmitting(true);
+    setError(null);
+
+    try {
+      // Send business query email via API route
+      const response = await fetch('/api/business-query', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({
+          name: formData.name,
+          email: formData.email.toLowerCase(),
+          phone: formData.phone,
+          queryType: formData.queryType,
+        }),
+      });
+
+      const result = await response.json();
+
+      if (!response.ok || !result.success) {
+        throw new Error(result.error || 'Failed to submit business query');
+      }
+
+      setIsSubmitted(true);
+    } catch (err) {
+      console.error('Business query submission error:', err);
+      const errorMessage = err instanceof Error ? err.message : 'An unexpected error occurred. Please try again.';
+      setError(errorMessage);
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  const renderPostSubmitContent = () => {
+    return (
+      <div className="text-center max-w-2xl mx-auto">
+        <h2 className="text-4xl font-extrabold mb-6">Thank You!</h2>
+        <p className="text-lg mb-6">
+          Your business inquiry has been submitted successfully. The TST Care Team will respond to your {formData.queryType} inquiry within 1-2 business days.
+        </p>
+        <p className="text-base text-gray-600">
+          We appreciate your interest in working with Toasted Sesame Therapy.
+        </p>
+      </div>
+    );
+  };
+
+  return (
+    <div className="min-h-screen bg-tst-cream py-16 px-4">
+      <div className="relative bg-white p-12 rounded-xl border-2 border-black shadow-brutalistLg max-w-5xl mx-auto">
+        {isSubmitted && (
+          <Confetti
+            width={width}
+            height={height}
+            recycle={false}
+            numberOfPieces={500}
+            tweenDuration={8000}
+            style={{ position: 'fixed', top: 0, left: 0, zIndex: 9999 }}
+          />
+        )}
+
+        {isSubmitted ? (
+          renderPostSubmitContent()
+        ) : (
+          <div className="max-w-4xl mx-auto text-center">
+            <h1 className="text-4xl md:text-5xl font-extrabold mb-6">
+              For Business Queries Only
+            </h1>
+
+            <div className="mb-8 p-4 bg-tst-yellow border-2 border-black rounded-lg">
+              <p className="text-lg font-medium">
+                For therapy, please{' '}
+                <Link
+                  href="/book/trauma"
+                  className="underline text-black hover:text-tst-purple font-bold transition-colors"
+                >
+                  book a consultation here
+                </Link>
+              </p>
+            </div>
+
+            <form onSubmit={handleSubmit}>
+              <div className="flex flex-col gap-8">
+                <Input
+                  type="text"
+                  id="name"
+                  name="name"
+                  placeholder="Your name"
+                  value={formData.name}
+                  onChange={handleChange}
+                  required
+                />
+
+                <div className="grid grid-cols-1 md:grid-cols-2 gap-8">
+                  <Input
+                    type="tel"
+                    id="phone"
+                    name="phone"
+                    placeholder="Phone number"
+                    value={formData.phone}
+                    onChange={handleChange}
+                    required
+                  />
+                  <Input
+                    type="email"
+                    id="email"
+                    name="email"
+                    placeholder="Your email"
+                    value={formData.email}
+                    onChange={handleChange}
+                    required
+                  />
+                </div>
+
+                <div className="text-left">
+                  <label htmlFor="queryType" className="block text-lg font-bold mb-3">
+                    Type of Business Query
+                  </label>
+                  <select
+                    id="queryType"
+                    name="queryType"
+                    value={formData.queryType}
+                    onChange={handleChange}
+                    required
+                    className="w-full p-4 text-lg border-2 border-black bg-white rounded-lg shadow-brutalistSm hover:bg-tst-purple hover:shadow-brutalist transition-all duration-200 focus:outline-none focus:ring-2 focus:ring-tst-purple focus:border-tst-purple"
+                  >
+                    {queryOptions.map((option) => (
+                      <option key={option.value} value={option.value}>
+                        {option.label}
+                      </option>
+                    ))}
+                  </select>
+                </div>
+
+                <div className="mt-4">
+                  <Button
+                    type="submit"
+                    className="bg-tst-yellow py-3"
+                    wrapperClassName="w-full"
+                    disabled={isSubmitting}
+                  >
+                    {isSubmitting ? 'Submitting...' : 'Submit Business Query'}
+                  </Button>
+                </div>
+
+                {error && (
+                  <div className="bg-red-50 border-2 border-red-200 rounded-lg p-4 mt-4">
+                    <p className="text-red-700 font-medium">{error}</p>
+                  </div>
+                )}
+              </div>
+            </form>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default BusinessQueriesPage;

--- a/src/app/thank-you/page.tsx
+++ b/src/app/thank-you/page.tsx
@@ -1,19 +1,37 @@
-import React from 'react';
+'use client';
+
+import React, { useState, useEffect } from 'react';
 import type { Metadata } from 'next';
 import Section from '@/components/Section/Section';
 import Button from '@/components/Button/Button';
 import { CheckCircle, Calendar, Clock, Mail } from 'lucide-react';
 import Link from 'next/link';
+import Confetti from 'react-confetti';
 
-export const metadata: Metadata = {
-  title: 'Thank You - Consultation Booked | Toasted Sesame Therapy',
-  description: 'Your free 15-minute consultation has been booked successfully. Check your email for confirmation details.',
-  robots: 'noindex, nofollow',
+const useWindowSize = () => {
+  const [size, setSize] = useState({ width: 0, height: 0 });
+  useEffect(() => {
+    const handleResize = () =>
+      setSize({ width: window.innerWidth, height: window.innerHeight });
+    handleResize();
+    window.addEventListener('resize', handleResize);
+    return () => window.removeEventListener('resize', handleResize);
+  }, []);
+  return size;
 };
 
 export default function ThankYouPage() {
+  const { width, height } = useWindowSize();
   return (
     <Section className="min-h-screen flex items-center justify-center bg-gray-50 px-4">
+      <Confetti
+        width={width}
+        height={height}
+        recycle={false}
+        numberOfPieces={500}
+        tweenDuration={8000}
+        style={{ position: 'fixed', top: 0, left: 0, zIndex: 9999 }}
+      />
       <div className="w-full max-w-2xl">
         <div className="bg-white rounded-xl border-2 border-black shadow-brutalistLg overflow-hidden text-center">
           {/* Header */}

--- a/src/components/Footer/Footer.tsx
+++ b/src/components/Footer/Footer.tsx
@@ -79,6 +79,14 @@ const Footer = () => {
                     Contact
                   </HoverLink>
                 </li>
+                <li>
+                  <HoverLink
+                    href="/business-queries"
+                    className="text-white/90 hover:text-white transition-colors font-medium"
+                  >
+                    Business Queries
+                  </HoverLink>
+                </li>
               </ul>
             </div>
           )}


### PR DESCRIPTION
- Create /business-queries page with ContactForm-inspired design
- Add business query dropdown with neo-brutalist styling (referrals, collaboration, consultation, training, media, other)
- Implement Resend API route for sending emails to kato@toastedsesametherapy.com
- Add "Business Queries" link to footer navigation
- Include therapy redirect notice to guide users to proper booking flow
- Add confetti animation to /thank-you page for consistent celebration UX
- No database storage - email-only functionality as requested

🤖 Generated with [Claude Code](https://claude.ai/code)