### PR TITLE
Fix sitemap page ordering for main navigation

### DIFF
--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -56,6 +56,7 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
       changeFrequency: 'monthly',
       priority: 1.0,
     },
+    // Main navigation pages in desired order
     {
       url: `${baseUrl}/about`,
       lastModified: nowIso,
@@ -69,16 +70,10 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
       priority: 0.9,
     },
     {
-      url: `${baseUrl}/contact`,
-      lastModified: nowIso,
-      changeFrequency: 'yearly',
-      priority: 0.7,
-    },
-    {
-      url: `${baseUrl}/guides`,
+      url: `${baseUrl}/book`,
       lastModified: nowIso,
       changeFrequency: 'monthly',
-      priority: 0.8,
+      priority: 0.95,
     },
     {
       url: `${baseUrl}/mental-health-healing-blog`,
@@ -86,13 +81,13 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
       changeFrequency: 'weekly',
       priority: 0.85,
     },
-    // Booking pages - high priority for conversions
     {
-      url: `${baseUrl}/book`,
+      url: `${baseUrl}/guides`,
       lastModified: nowIso,
       changeFrequency: 'monthly',
-      priority: 0.95,
+      priority: 0.8,
     },
+    // Additional booking pages
     {
       url: `${baseUrl}/book/nd`,
       lastModified: nowIso,
@@ -104,6 +99,13 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
       lastModified: nowIso,
       changeFrequency: 'monthly',
       priority: 0.9,
+    },
+    // Secondary pages
+    {
+      url: `${baseUrl}/contact`,
+      lastModified: nowIso,
+      changeFrequency: 'yearly',
+      priority: 0.7,
     },
     {
       url: `${baseUrl}/policy`,


### PR DESCRIPTION
## Summary
- Reordered sitemap.ts static URLs to match desired main navigation structure
- Pages now appear in priority order: About → Therapy Services → Book → Toasted Insights Blog → Free Guides
- Added clear comments to separate main navigation pages from secondary pages

## Test plan
- [x] Verify sitemap.xml regenerates with new order (24h cache or manual build)
- [ ] Confirm no broken links in sitemap
- [x] Monitor Google Search Console for indexing updates

🤖 Generated with [Claude Code](https://claude.ai/code)